### PR TITLE
Preserve blank lines in brackets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 - Add `--use-tabs` / `-T` to indent with tabs instead of spaces. (#1)
 - Add `--tab-width` / `-w` to specify how many spaces a tab or indentation level
   represents (default: 4). (#1)
+- Add `--keep-blank-lines-in-brackets` to preserve single blank lines within brackets
+  (tuples, lists, dictionaries, function arguments, etc.). (#3)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Options:
   -T, --use-tabs                  Indent with tabs instead of spaces.
   -w, --tab-width INTEGER         How many spaces per indentation level.
                                   [default: 4]
+  --keep-blank-lines-in-brackets  Preserve single blank lines inside brackets
+                                  (tuples, lists, dictionaries, function
+                                  arguments, etc.).
 ```
 
 ---

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -253,6 +253,14 @@ def validate_regex(
     ),
 )
 @click.option(
+    "--keep-blank-lines-in-brackets",
+    is_flag=True,
+    help=(
+        "Preserve single blank lines inside brackets (tuples, lists, "
+        "dictionaries, function arguments, etc.)."
+    ),
+)
+@click.option(
     "--check",
     is_flag=True,
     help=(
@@ -396,6 +404,7 @@ def main(
     skip_string_normalization: bool,
     skip_magic_trailing_comma: bool,
     experimental_string_processing: bool,
+    keep_blank_lines_in_brackets: bool,
     quiet: bool,
     verbose: bool,
     required_version: str,
@@ -438,6 +447,7 @@ def main(
         string_normalization=not skip_string_normalization,
         magic_trailing_comma=not skip_magic_trailing_comma,
         experimental_string_processing=experimental_string_processing,
+        keep_blank_lines_in_brackets=keep_blank_lines_in_brackets,
     )
 
     if code is not None:

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -55,7 +55,11 @@ class Line:
 
         Inline comments are put aside.
         """
-        has_value = leaf.type in BRACKETS or bool(leaf.value.strip())
+        has_value = (
+            leaf.type in BRACKETS
+            or leaf.type == STANDALONE_COMMENT
+            or bool(leaf.value.strip())
+        )
         if not has_value:
             return
 
@@ -392,6 +396,8 @@ class Line:
             res += str(leaf)
         for comment in itertools.chain.from_iterable(self.comments.values()):
             res += str(comment)
+        if res == indent:
+            res = ""
 
         return res + "\n"
 

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -106,6 +106,7 @@ class Mode:
     is_ipynb: bool = False
     magic_trailing_comma: bool = True
     experimental_string_processing: bool = False
+    keep_blank_lines_in_brackets: bool = False
 
     @property
     def use_tabs(self) -> bool:

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -53,6 +53,7 @@ STATEMENT: Final = {
 }
 STANDALONE_COMMENT: Final = 153
 token.tok_name[STANDALONE_COMMENT] = "STANDALONE_COMMENT"
+COMMENTS: Final = {token.COMMENT, STANDALONE_COMMENT}
 LOGIC_OPERATORS: Final = {"and", "or"}
 COMPARATORS: Final = {
     token.LESS,

--- a/tests/data/ex_keep_blank_lines_in_brackets.py
+++ b/tests/data/ex_keep_blank_lines_in_brackets.py
@@ -1,0 +1,171 @@
+x = [
+
+    "a",
+
+]
+
+x = [
+
+    # Comment
+    "a",
+    # Comment
+
+]
+
+x = [
+    "a",
+
+
+    "b",
+]
+
+x = [
+
+    "a",  # Comment
+
+
+    "b",  # Comment
+
+]
+
+x = [
+    "a",
+
+
+    # Comment
+
+
+    "b",
+]
+
+x = [
+    # Comment
+
+
+    # Comment
+]
+
+x = [
+
+    {
+
+        (
+
+            # Comment
+            "a",
+
+
+            # Comment
+            "b",
+
+        ),
+
+
+        # Comment
+
+
+        (
+
+            "c",
+
+            "d",
+
+        ),
+
+    },
+
+]
+
+test(
+
+    # Comment
+    "a",
+
+
+    # Comment
+    "b",
+
+)
+
+if True:
+    x = [
+
+        "a",
+
+
+        "b",
+
+    ]
+
+# output
+
+x = [
+    "a",
+]
+
+x = [
+    # Comment
+    "a",
+    # Comment
+]
+
+x = [
+    "a",
+
+    "b",
+]
+
+x = [
+    "a",  # Comment
+
+    "b",  # Comment
+]
+
+x = [
+    "a",
+
+    # Comment
+
+    "b",
+]
+
+x = [
+    # Comment
+
+    # Comment
+]
+
+x = [
+    {
+        (
+            # Comment
+            "a",
+
+            # Comment
+            "b",
+        ),
+
+        # Comment
+
+        (
+            "c",
+
+            "d",
+        ),
+    },
+]
+
+test(
+    # Comment
+    "a",
+
+    # Comment
+    "b",
+)
+
+if True:
+    x = [
+        "a",
+
+        "b",
+    ]

--- a/tests/test_format_ex.py
+++ b/tests/test_format_ex.py
@@ -21,6 +21,13 @@ class TestSimpleFormatEX(BlackBaseTestCase):
     def test_indentation_tabs(self) -> None:
         self.check_file("ex_indentation_tabs", black.Mode(indentation="\t"))
 
+    @patch("black.dump_to_file", dump_to_stderr)
+    def test_keep_blank_lines_in_brackets(self) -> None:
+        self.check_file(
+            "ex_keep_blank_lines_in_brackets",
+            black.Mode(keep_blank_lines_in_brackets=True),
+        )
+
     def check_file(self, filename: str, mode: black.Mode, *, data: bool = True) -> None:
         source, expected = read_data(filename, data=data)
         actual = fs(source, mode=mode)


### PR DESCRIPTION
- Add `--keep-blank-lines-in-brackets` option to preserve single blank lines within brackets (tuples, lists, dictionaries, function arguments, etc.).