### PR TITLE
Fix cache invalidation

### DIFF
--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -157,11 +157,14 @@ class Mode:
             version_str = "-"
         parts = [
             version_str,
+            str(int(self.use_tabs)),
+            str(self.tab_width),
             str(self.line_length),
             str(int(self.string_normalization)),
             str(int(self.is_pyi)),
             str(int(self.is_ipynb)),
             str(int(self.magic_trailing_comma)),
             str(int(self.experimental_string_processing)),
+            str(int(self.keep_blank_lines_in_brackets)),
         ]
         return ".".join(parts)

--- a/tests/test_mode_ex.py
+++ b/tests/test_mode_ex.py
@@ -1,0 +1,19 @@
+import pytest
+
+from black.mode import Mode
+
+
+@pytest.mark.parametrize("indentation, expected", [("    ", False), ("\t", True)])
+def test_use_tabs(indentation: str, expected: bool) -> None:
+    result = Mode(indentation=indentation).use_tabs
+    assert result == expected
+
+
+def test_get_cache_key() -> None:
+    result = Mode(
+        indentation="\t",
+        tab_width=4,
+        keep_blank_lines_in_brackets=True,
+    ).get_cache_key()
+    expected = "-.1.4.88.1.0.0.1.0.1"
+    assert result == expected


### PR DESCRIPTION
Fix cache not being invalidated for `--use-tabs`, `--tab-width`, and `--keep-blank-lines-in-brackets`, causing files to not be reformatted sometimes.